### PR TITLE
Some improvements

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,6 +26,9 @@ ReStructuredText Usage
       recognizable.  It is also used to generate sample data, if the
       ``:showexample:`` option is included.
 
+   **:property-opt** *[type]* *identifier* **:** *description*
+      Same as above, but add an '(optional)' string at the end.
+
    **:proptype** *identifier* **:** *type*
       Set's the type of the property named *identifier*.  This is
       necessary if you are setting the property type to a hyperlinked

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,6 +34,9 @@ ReStructuredText Usage
       necessary if you are setting the property type to a hyperlinked
       value (e.g., :rst:role:`json:object` role instance).
 
+   **:propexample** *identifier* **:** *example*
+      Set's the example showed when the *showexample* option is enabled.
+
    **:showexample:**
       If this option is specified, then the rendered output will contain
       a generated example.  The example data is generated using the
@@ -138,6 +141,7 @@ example.
       :property street_address street: street address for this
          location
       :property city city: city name
+      :propexample city: New York
       :property state_abbr state: abbreviated state name
       :property postalcode zip: postal code for this address
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -105,6 +105,8 @@ generate example snippets if the *:showexample:* option is included.
 **user_name** links to the defintion for the Python :class:`str` type.
    Examples are generated using `faker.providers.internet`_.
 
+**[type]** by enclosing any type into [], it indicate a json array.
+
 Example Generation
 ------------------
 As mentioned elsewhere, this extensions uses the `fake-factory`_ library

--- a/sphinxjsondomain.py
+++ b/sphinxjsondomain.py
@@ -39,7 +39,7 @@ class JSONObject(directives.ObjectDescription):
                                             names=('property', 'property-opt', 'member'),
                                             rolename='prop',
                                             typerolename='jsonprop',
-                                            typenames=('proptype', 'type', 'propexample'))]
+                                            typenames=('proptype', 'type'))]
     """A list of fields that are implemented."""
 
     option_spec = {
@@ -472,7 +472,7 @@ class PropertyDefinition(object):
                         name = tokens[1]
 
                         self.property_qualifiers[name] = self.property_qualifiers.get(name, PropertyQualifier())
-                        self.property_qualifiers[name].example_data = content[0][0]
+                        self.property_qualifiers[name].example_data = content[0][0].lstrip()
 
                     elif tokens[0] == 'options':
                         name = tokens[1]


### PR DESCRIPTION
Hello,

In these commits I add the following functionalities:

- a new directive to specify an optional json property: ":property-opt"
    `:property-opt uuid4 id: unique identifier`
    will render to:
    `id (uuid4) – action group unique identifier (optional)`

- json array support by enclosing the type into [], example:
    `:property [string] flags: a list of flags`
    will render to json:
    `"flags": [
        "qROWvQcsijJXFvMZAFpd",
        "GzHoSHdmUNusmNBhGVGp"
    ]`
- :propexample to specify the example to be shown when :showexample: is enabled, example:
    `:property sentence label: label`
    `:propexample label: foo`
    will render to:
    `"label": "foo",`

Thank you for your feedback