### PR TITLE
Some improvements

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -26,6 +26,9 @@ ReStructuredText Usage
       recognizable.  It is also used to generate sample data, if the
       ``:showexample:`` option is included.
 
+   **:property-opt** *[type]* *identifier* **:** *description*
+      Same as above, but add an '(optional)' string at the end.
+
    **:proptype** *identifier* **:** *type*
       Set's the type of the property named *identifier*.  This is
       necessary if you are setting the property type to a hyperlinked

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,6 +34,9 @@ ReStructuredText Usage
       necessary if you are setting the property type to a hyperlinked
       value (e.g., :rst:role:`json:object` role instance).
 
+   **:propexample** *identifier* **:** *example*
+      Set's the example showed when the *showexample* option is enabled.
+
    **:showexample:**
       If this option is specified, then the rendered output will contain
       a generated example.  The example data is generated using the
@@ -138,6 +141,7 @@ example.
       :property street_address street: street address for this
          location
       :property city city: city name
+      :propexample city: New York
       :property state_abbr state: abbreviated state name
       :property postalcode zip: postal code for this address
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -105,6 +105,8 @@ generate example snippets if the *:showexample:* option is included.
 **user_name** links to the defintion for the Python :class:`str` type.
    Examples are generated using `faker.providers.internet`_.
 
+**[type]** by enclosing any type into [], it indicate a json array.
+
 Example Generation
 ------------------
 As mentioned elsewhere, this extensions uses the `fake-factory`_ library

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,13 @@ def read_requirements(name):
 
 setuptools.setup(
     name='sphinx-jsondomain',
-    version='0.0.3',
+    version='0.0.4',
     url='https://github.com/dave-shawley/sphinx-jsondomain',
     description='Describe JSON document structures in sphinx',
     long_description='\n'+open('README.rst').read(),
     license='BSD',
-    author='Dave Shawley',
-    author_email='daveshawley+python@gmail.com',
+    author='Dave Shawley, Eliott Dumeix',
+    author_email='eliott.dumeix@gmail.com',
     py_modules=['sphinxjsondomain'],
     install_requires=read_requirements('installation.txt'),
     classifiers=[

--- a/sphinxjsondomain.py
+++ b/sphinxjsondomain.py
@@ -14,6 +14,22 @@ except ImportError:
     yaml = None
 
 
+def is_json_array(typename):
+    """ Check if a property type is an array.
+        For example: [int], [uuid4] are array
+    """
+    return typename and typename.startswith('[') and typename.endswith(']')
+
+
+def strip_json_array(typename):
+    """ Strip json array enclosing brackets from a typename.
+        [int] -> int
+    """
+    if typename and typename.startswith('[') and typename.endswith(']'):
+        return typename[1:-1]
+    return typename
+
+
 class JsonField(docfields.TypedField):
     def __init__(self, name, names=(), typenames=[], label=None, examplenames=(),
                  rolename=None, typerolename=None, can_collapse=False):
@@ -31,30 +47,100 @@ class JsonFieldTransformer(docfields.DocFieldTransformer):
             for name in fieldtype.examplenames:
                 self.examplemap[name] = True
 
-    def transform_all(self, node):
+    def transform(self, node):
         # type: (nodes.Node) -> None
-        """Transform all field list children of a node."""
-        # don't traverse, only handle field lists that are immediate children
+        """Transform a single field list *node*."""
+        typemap = self.typemap
 
-        for child in node:
-            if isinstance(child, nodes.field_list):
+        entries = []
+        groupindices = {}  # type: Dict[unicode, int]
+        types = {}  # type: Dict[unicode, Dict]
 
-                # remove examplenames nodes
-                nodes_to_delete = []
-                for c in child.children:
-                    fieldname, fieldbody = c
-                    try:
-                        # split into field type and argument
-                        fieldtype, fieldarg = fieldname.astext().split(None, 1)
-                        if fieldtype in self.examplemap:
-                            nodes_to_delete.append(c)
-                    except ValueError:
-                        pass
+        # step 1: traverse all fields and collect field types and content
+        for field in node:
+            fieldname, fieldbody = field
+            try:
+                # split into field type and argument
+                fieldtype, fieldarg = fieldname.astext().split(None, 1)
+            except ValueError:
+                # maybe an argument-less field type?
+                fieldtype, fieldarg = fieldname.astext(), ''
+            typedesc, is_typefield = typemap.get(fieldtype, (None, None))
 
-                for n in nodes_to_delete:
-                    child.children.remove(n)
+            # collect the content, trying not to keep unnecessary paragraphs
+            if docfields._is_single_paragraph(fieldbody):
+                content = fieldbody.children[0].children
+            else:
+                content = fieldbody.children
 
-                self.transform(child)
+            # sort out unknown fields
+            if typedesc is None or typedesc.has_arg != bool(fieldarg):
+                continue
+
+            typename = typedesc.name
+
+            # if the field specifies a type, put it in the types collection
+            if is_typefield:
+                # filter out only inline nodes; others will result in invalid
+                # markup being written out
+                content = [n for n in content if isinstance(n, nodes.Inline) or
+                           isinstance(n, nodes.Text)]
+                if content:
+                    types.setdefault(typename, {})[fieldarg] = content
+                continue
+
+            # also support syntax like ``:param type name:``
+            if typedesc.is_typed:
+                try:
+                    argtype, argname = fieldarg.split(None, 1)
+                except ValueError:
+                    pass
+                else:
+                    xrefs = typedesc.make_xrefs(
+                        nodes.Text(argtype),
+                        self.directive.domain,
+                        nodes.Text(argtype),
+                    )
+                    xrefs[0].attributes['json:name'] = strip_json_array(nodes.Text(argtype))
+                    types.setdefault(typename, {})[argname] = xrefs
+                    fieldarg = argname
+
+            translatable_content = nodes.inline(fieldbody.rawsource,
+                                                translatable=True)
+            translatable_content.document = fieldbody.parent.document
+            translatable_content.source = fieldbody.parent.source
+            translatable_content.line = fieldbody.parent.line
+            translatable_content += content
+
+            # grouped entries need to be collected in one entry, while others
+            # get one entry per field
+            if typedesc.is_grouped:
+                if typename in groupindices:
+                    group = entries[groupindices[typename]]
+                else:
+                    groupindices[typename] = len(entries)
+                    group = [typedesc, []]
+                    entries.append(group)
+                entry = typedesc.make_entry(fieldarg, [translatable_content])
+                group[1].append(entry)
+            else:
+                entry = typedesc.make_entry(fieldarg, [translatable_content])
+                entries.append([typedesc, entry])
+
+        # step 2: all entries are collected, construct the new field list
+        new_list = nodes.field_list()
+        for entry in entries:
+            if isinstance(entry, nodes.field):
+                # pass-through old field
+                new_list += entry
+            else:
+                fieldtype, content = entry
+                fieldtypes = types.get(fieldtype.name, {})
+                env = self.directive.state.document.settings.env
+                new_list += fieldtype.make_field(fieldtypes, self.directive.domain,
+                                                 content, env=env)
+
+        node.replace_self(new_list)
 
 
 class JSONObject(directives.ObjectDescription):
@@ -351,13 +437,16 @@ class JSONDomain(domains.Domain):
         the type is ``uri``, then a link to the RFC is generated.
 
         """
+
         if node.get('json:name'):
+
             objdef = self.get_object(node['json:name'])
             if objdef:
                 return node_utils.make_refnode(builder, fromdocname,
                                                objdef.docname, objdef.key,
                                                contnode)
-        if typ == 'jsonprop':
+
+        if typ in self.REF_TYPES:
             try:
                 ref = nodes.reference(internal=False)
                 ref['refuri'], ref['reftitle'] = self.REF_TYPES[target]
@@ -490,8 +579,8 @@ class PropertyDefinition(object):
                             name = tokens[1]
 
                         # check if name is enclosed by []
-                        if typ and typ.startswith('[') and typ.endswith(']'):
-                            typ = typ[1:-1]
+                        if is_json_array(typ):
+                            typ = strip_json_array(typ)
 
                             self.property_qualifiers[name] = self.property_qualifiers.get(name, PropertyQualifier())
                             self.property_qualifiers[name].is_array = True

--- a/sphinxjsondomain.py
+++ b/sphinxjsondomain.py
@@ -696,6 +696,8 @@ class PropertyDefinition(object):
                     value = fake_factory.pystr()
                 elif typ in ('boolean', 'bool'):
                     value = fake_factory.pybool()
+                elif typ in ('float'):
+                    value = fake_factory.pyfloat()
                 elif typ == 'null':
                     value = None
 

--- a/sphinxjsondomain.py
+++ b/sphinxjsondomain.py
@@ -437,9 +437,7 @@ class JSONDomain(domains.Domain):
         the type is ``uri``, then a link to the RFC is generated.
 
         """
-
         if node.get('json:name'):
-
             objdef = self.get_object(node['json:name'])
             if objdef:
                 return node_utils.make_refnode(builder, fromdocname,
@@ -651,7 +649,15 @@ class PropertyDefinition(object):
             # the data generator
             def gen_data():
                 if name in self.property_qualifiers and self.property_qualifiers[name].example_data:
-                    return self.property_qualifiers[name].example_data
+
+                    # try to cast data to user type
+                    data = self.property_qualifiers[name].example_data
+                    try:
+                        data = __builtins__[typ](data)
+                    except:
+                        pass
+
+                    return data
                 else:
                     return self.generate_sample_data_for_type(typ, all_objects, fake_factory)
 


### PR DESCRIPTION
Hello,

In these commits I add the following functionalities:

- a new directive to specify an optional json property: ":property-opt"
    `:property-opt uuid4 id: unique identifier`
    will render to:
    `id (uuid4) – action group unique identifier (optional)`

- json array support by enclosing the type into [], example:
    `:property [string] flags: a list of flags`
    will render to json:
    `"flags": [
        "qROWvQcsijJXFvMZAFpd",
        "GzHoSHdmUNusmNBhGVGp"
    ]`

- :propexample to specify the example to be shown when :showexample: is enabled, example:
    `:property sentence label: label`
    `:propexample label: foo`
    will render to:
    `"label": "foo",`

- user defined json object works directly in property:
    `:property myJsonObject foo: description`
    `:property [myJsonObject] foo: description`

Thank you for your feedback